### PR TITLE
Add more entries to .gitignore and remove ignored files from the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules
 src.zip
 dist/main.js
+.idea
+.vscode
+desktop.ini
+.DS_Store

--- a/src/XIT/desktop.ini
+++ b/src/XIT/desktop.ini
@@ -1,4 +1,0 @@
-[ViewState]
-Mode=
-Vid=
-FolderType=Documents

--- a/src/desktop.ini
+++ b/src/desktop.ini
@@ -1,4 +1,0 @@
-[ViewState]
-Mode=
-Vid=
-FolderType=Documents


### PR DESCRIPTION
This PR adds more .gitignore entries:
1. .idea folder is used by JetBrains IDEs (I have one)
2. .vscode is used by VSCode
3. desktop.ini is a hidden Windows-only file for Windows Explorer; it should not be present in the repository
4. .DS_Store is like desktop.ini, but for Mac

This PR also deletes main.js, since it is in the .gitignore and can be regenerated by running build/package command (don't forget to run it before publishing, lol)