### PR TITLE
Extract Settings handling to a separate file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "plotly.js-dist-min": "^2.30.1"
       },
       "devDependencies": {
-        "@types/chrome": "^0.0.50",
+        "@types/chrome": "^0.0.268",
         "@types/plotly.js-dist-min": "^2.3.4",
         "ts-loader": "^3.1.0",
         "typescript": "^5.0.4",
@@ -37,12 +37,13 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.50.tgz",
-      "integrity": "sha512-P5FARarO3es0+BtxdJ3XpN0ZpG3mGgxw9W3sF2tco+1HaldDwnFOxgZVfdbWAPFPmejLqJGlt0tf8f7CTMDHFQ==",
+      "version": "0.0.268",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.268.tgz",
+      "integrity": "sha512-7N1QH9buudSJ7sI8Pe4mBHJr5oZ48s0hcanI9w3wgijAlv1OZNUZve9JR4x42dn5lJ5Sm87V1JNfnoh10EnQlA==",
       "dev": true,
       "dependencies": {
-        "@types/filesystem": "*"
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
       }
     },
     "node_modules/@types/filesystem": {
@@ -58,6 +59,12 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
       "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.15.tgz",
+      "integrity": "sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==",
       "dev": true
     },
     "node_modules/@types/plotly.js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@types/chrome": "^0.0.50",
+    "@types/chrome": "^0.0.268",
     "@types/plotly.js-dist-min": "^2.3.4",
     "ts-loader": "^3.1.0",
     "typescript": "^5.0.4",

--- a/src/CompactUI.ts
+++ b/src/CompactUI.ts
@@ -1,7 +1,7 @@
 import { Module } from "./ModuleRunner";
 import { getBuffersFromList, createTextSpan } from "./util";
 import { Selector } from "./Selector";
-import { WithStyles, Style } from "Style";
+import { WithStyles, Style } from "./Style";
 import { Exchanges } from "./GameProperties";
 
 

--- a/src/ModuleRunner.ts
+++ b/src/ModuleRunner.ts
@@ -1,7 +1,8 @@
 import {XITHandler} from "./XITHandler";
-import { showBuffer, setSettings, getLocalStorage, getBuffers } from "./util";
+import { showBuffer, getLocalStorage, getBuffers } from "./util";
 import { FriendlyNames } from "./GameProperties";
 import { Selector } from "./Selector";
+import { saveSettings, Settings } from './Settings';
 
 export interface Module {
   run(buffers: any[]);
@@ -23,13 +24,13 @@ export class ModuleRunner {
   private readonly modules: ModuleEntry[];	// The list of modules run by the extension
   private readonly xit: XITHandler;	// The XIT module, run separately
   private userInfo;
-  private result;	// The stored settings
+  private result: Settings;	// The stored settings
   private iteration;
-  constructor(modules: Module[], result, webData, userInfo, browser) {
+  constructor(modules: Module[], result: Settings, webData, userInfo) {
 	// Construct global variables
 	this.iteration = 0;
     this.modules = modules.map(m => this.moduleToME(m));
-	this.xit = new XITHandler(result, userInfo, webData, this.modules, browser);
+	this.xit = new XITHandler(result, userInfo, webData, this.modules);
 	this.result = result;
 	this.userInfo = userInfo;
 	
@@ -90,12 +91,12 @@ export class ModuleRunner {
 	this.xit.run(buffers);
 	
 	// Run intro if it hasn't run already
-	if(!this.result["PMMGExtended"]["loaded_before"])
+	if(!this.result.PMMGExtended.loaded_before)
 	{
-		this.result["PMMGExtended"]["loaded_before"] = showBuffer("XIT START");
-		if(this.result["PMMGExtended"]["loaded_before"])
+		this.result.PMMGExtended.loaded_before = showBuffer("XIT START");
+		if(this.result.PMMGExtended.loaded_before)
 		{
-			setSettings(this.result);
+			saveSettings(this.result);
 		}
 	}
 	

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -1,0 +1,47 @@
+import { CHROME } from './env';
+
+const defaultSettings = {
+	PMMGExtended: {
+		loaded_before: false
+	}
+};
+
+export type Settings = typeof defaultSettings & { [key: string]: any };
+const settingsKey = "PMMGExtended";
+
+export async function loadSettings() {
+	let data = await loadDataFromStorage();
+	if (data[settingsKey] === undefined) {
+		data = structuredClone(defaultSettings);
+	}
+
+	migrate(data);
+	return <Settings>data;
+}
+
+function migrate(data: any) {
+	const settings = data[settingsKey];
+	settings.loaded_before = settings.loaded_before ?? false;
+	settings.disabled = settings.disabled ?? ["ScreenUnpack"];
+	delete settings.burn_display_settings;
+}
+
+export async function saveSettings(settings: Settings) {
+	if (CHROME) {
+		return await chrome.storage.local.set(settings);
+	}
+	else {
+		return await browser.storage.local.get(settings);
+	}
+}
+
+async function loadDataFromStorage() {
+	if (CHROME) {
+		console.log("PMMG: Chromium detected");
+		return await chrome.storage.local.get(settingsKey);
+	}
+	else {
+		console.log("PMMG: Firefox detected");
+		return await browser.storage.local.get(settingsKey);
+	}
+}

--- a/src/XITHandler.ts
+++ b/src/XITHandler.ts
@@ -36,6 +36,7 @@ import {PrUN, Prosperity, Sheets, Wiki, PrunPlanner, FIO} from "./XIT/Web";
 import {Checklists} from "./XIT/Checklists";
 import {Execute} from "./XIT/Execute";
 import {Notes} from "./XIT/Notes";
+import { CHROME } from './env';
 
 // This is the structure all classes should follow. For some reason extending classes in other files shows XITModule as undefined.
 // Not the best solution, but it works. Be careful implementing new modules that they include these functions.
@@ -94,16 +95,14 @@ export class XITHandler implements Module {
   private webData;
   private modules;
   private pmmgSettings;
-  private browser;
   private userInfo;
   
-  constructor(pmmgSettings, userInfo, webData, modules, browser)
+  constructor(pmmgSettings, userInfo, webData, modules)
   {  
 	this.userInfo = userInfo;
 	this.webData = webData;
 	this.modules = modules;
 	this.pmmgSettings = pmmgSettings;
-	this.browser = browser;
   }
   cleanup() {
     //genericCleanup(this.tag);	// Don't clean up because causes flashing when doing asynchronous requests
@@ -161,7 +160,7 @@ export class XITHandler implements Module {
 					refreshButton.classList.add("button-upper-right");
 					refreshButton.classList.add(this.tag);
 					refreshButton.style.fontSize = "16px";
-					refreshButton.style.paddingTop = this.browser == "chromium" ? "12px" : "7px";
+					refreshButton.style.paddingTop = CHROME ? "12px" : "7px";
 					refreshButton.classList.add("refresh");
 					(buffer.children[3] || buffer.children[2]).insertBefore(refreshButton, (buffer.children[3] || buffer.children[2]).firstChild);
 				}

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,1 @@
+export const CHROME = chrome !== undefined;


### PR DESCRIPTION
One of the main problems currently is the widespread use of `pmmgSettings["PMMGExtended"][key] || someValue` code, which has two wonderful properties: first, it is basically a visual noise that obscures important code/calculations, and second, it completely annihilates the type-checking capabilities of TypeScript compiler.
This PR is the first step to reducing this noise and improving the type-checking in the project. I will gradually extract all the settings into the Settings file, and you can see how it is currently done with a loaded_before property already.
Looking forward, we will also remove the `PMMGExtended` property, as it is in itself also just a noise.