### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = tab
+tab_width = 4
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true


### PR DESCRIPTION
https://editorconfig.org/

Many editors/IDEs support this configuration file, which reduces the chance of accidental tab/space, crlf/lf, or charset mixups.