### PR TITLE
strip numeric prefix from screen unpack

### DIFF
--- a/src/ScreenUnpack.ts
+++ b/src/ScreenUnpack.ts
@@ -106,7 +106,7 @@ export class ScreenUnpack implements Module {
     const nbitMainClassList = navbar.children[2].children[0].classList;
     const nbitUnderlineClassList = navbar.children[2].children[1].classList;
     const button = `<a class="${navbarItemClassList}" href="${link}">
-                        <div class="${nbitMainClassList}" style="color: inherit" >${screenName}</div>
+                        <div class="${nbitMainClassList}" style="color: inherit" >${screenName.replace(/^\d+:\s*/, "")}</div>
                         <div class="${nbitUnderlineClassList}"></div>
                     </a>`;
     const buttonElem = createNode(button) as HTMLElement;


### PR DESCRIPTION
This makes it possible to order the screens without taking horizontal space, e.g.:

![Screenshot_2024-11-25_12-12-52](https://github.com/user-attachments/assets/fe006d90-ef9f-4e10-9cc0-948bbe78ce70)
